### PR TITLE
use library code for CI test

### DIFF
--- a/.github/workflows/python_version_tests.yaml
+++ b/.github/workflows/python_version_tests.yaml
@@ -32,6 +32,10 @@ jobs:
         run: poetry run python -m unittest
         working-directory: library/tests
 
+      - name: Install fy script
+        run: poetry install
+        working-directory: cli
+
       - name: Regenerate Library
         run: ../../fy.sh
         working-directory: library/src

--- a/.github/workflows/python_version_tests.yaml
+++ b/.github/workflows/python_version_tests.yaml
@@ -31,3 +31,7 @@ jobs:
       - name: Test
         run: poetry run python -m unittest
         working-directory: library/tests
+
+      - name: Regenerate Library
+        run: ../../fy.sh
+        working-directory: library/src

--- a/.github/workflows/python_version_tests.yaml
+++ b/.github/workflows/python_version_tests.yaml
@@ -38,7 +38,7 @@ jobs:
         run: poetry install
         working-directory: cli
 
-      - name: Regenerate Library
+      - name: Test library fy code
         shell: bash
         run: ../../fy.sh
         working-directory: library/src

--- a/.github/workflows/python_version_tests.yaml
+++ b/.github/workflows/python_version_tests.yaml
@@ -16,8 +16,8 @@ jobs:
       - uses: actions/checkout@v3
 
       - name: Install Poetry
-        run: pipx install poetry
         shell: bash
+        run: pipx install poetry
 
       - uses: actions/setup-python@v4
         with:
@@ -29,13 +29,16 @@ jobs:
         run: poetry install --with dev
 
       - name: Test
+        shell: bash
         run: poetry run python -m unittest
         working-directory: library/tests
 
       - name: Install fy script
+        shell: bash
         run: poetry install
         working-directory: cli
 
       - name: Regenerate Library
+        shell: bash
         run: ../../fy.sh
         working-directory: library/src

--- a/fy.sh
+++ b/fy.sh
@@ -1,15 +1,14 @@
 #!/usr/bin/env bash
 
+# Instructs Bash to exit immediately if any command in the script returns a non-zero exit code.
+set -e
+
 CURRENT_DIR=$(pwd)
 SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
 FY_CLI_DIR="${SCRIPT_DIR}/cli"
 
-pushd "${FY_CLI_DIR}" >> /dev/null || exit 1
+pushd "${FY_CLI_DIR}" >> /dev/null
 
 poetry run fy --root "$CURRENT_DIR" "$CURRENT_DIR"
 
-EXIT_CODE=$?
-
-popd || exit 1
-
-exit $EXIT_CODE
+popd

--- a/fy.sh
+++ b/fy.sh
@@ -9,6 +9,6 @@ FY_CLI_DIR="${SCRIPT_DIR}/cli"
 
 pushd "${FY_CLI_DIR}" >> /dev/null
 
-poetry run fy --root "$CURRENT_DIR" "$CURRENT_DIR"
+poetry run fy --root "$CURRENT_DIR" "$CURRENT_DIR" | exit
 
 popd

--- a/fy.sh
+++ b/fy.sh
@@ -1,14 +1,15 @@
 #!/usr/bin/env bash
 
-# Instructs Bash to exit immediately if any command in the script returns a non-zero exit code.
-set -e
-
 CURRENT_DIR=$(pwd)
 SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
 FY_CLI_DIR="${SCRIPT_DIR}/cli"
 
-pushd "${FY_CLI_DIR}" >> /dev/null
+pushd "${FY_CLI_DIR}" >> /dev/null || exit 1
 
-poetry run fy --root "$CURRENT_DIR" "$CURRENT_DIR" | exit
+poetry run fy --root "$CURRENT_DIR" "$CURRENT_DIR"
 
-popd
+EXIT_CODE=$?
+
+popd || exit 1
+
+exit $EXIT_CODE


### PR DESCRIPTION
The added test prevents own library ___fy___ code from breaking. The Python code can be working and the tests passing, but we do not know if ___fy___ code is broken within `library`.

This is how it looks when it fails:
<img width="1273" alt="Screenshot 2024-08-31 at 3 24 52 PM" src="https://github.com/user-attachments/assets/0d489863-03bb-4bde-8965-ce7d58deee39">
